### PR TITLE
Quick release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = stsci.imagestats
-version = 1.4.1.dev
-vdate = 11-Dec-2009
+version = 1.4.2
+vdate = 31-May-2018
 author = Warren Hack, Christopher Hanley
 author-email = help@stsci.edu
 summary = Compute various useful statistical values for array objects
-home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
+home-page = https://github.com/spacetelescope/stsci.imagestats
 classifier = 
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: BSD License


### PR DESCRIPTION
* Bump version
* Change home URL

_This  does nothing more than get rid of the `.dev0` version suffix from otherwise production code._