### PR TITLE
Bump fallback version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,8 @@ long_description_content_type=text/x-rst
 author=Warren Hack, Christopher Hanley
 author_email=help@stsci.edu
 license=BSD-3-Clause
-version=1.6.0
-version_date=12-February-2019
+version=1.6.1
+version_date=09-March-2019
 edit_on_github=False
 url=http://www.stsci.edu/
 


### PR DESCRIPTION
To 1.6.1 -- despite using `relic`.