### PR TITLE
Update test matrix and minimum requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,57 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: py311-test
-        - linux: py39-numpy120-test
-        - windows: py310-test
-        - macos: py310-test
+        # Make sure that packaging will work
+        - name: pep517 build
+          linux: twine
+
+        - name: Security audit
+          linux: bandit
+
+        - name: PEP 8
+          linux: codestyle
+
+        - name: Python 3.7
+          linux: py37-test-numpy116
+          posargs: -v
+
+        - name: Python 3.8
+          linux: py38-test
+          posargs: -v
+
+        - name: Python 3.9
+          linux: py39-test
+          posargs: -v
+
+        - name: Python 3.10
+          linux: py310-test
+          posargs: -v
+
+        - name: Python 3.11 (Windows)
+          windows: py311-test
+          posargs: -v
+
+        - name: Python 3.11 (OSX)
+          macos: py311-test
+          posargs: -v
+
+        - name: Python 3.11 with coverage
+          linux: py311-test-cov
+          posargs: -v
+          coverage: codecov
+
+        - name: Python 3.12 (Windows)
+          windows: py312-test
+          posargs: -v
+
+        - name: Python 3.12 (OSX)
+          macos: py311-test
+          posargs: -v
+
+        - name: Python 3.12
+          linux: py311-test-cov
+          posargs: -v
+
+        - name: Python 3.12 with dev version of dependencies
+          linux: py312-test-devdeps
+          posargs: -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
     "Development Status :: 7 - Inactive",
 ]
 dependencies = [
-    "numpy>=1.20",
+    "numpy>=1.16",
+    "packaging>=19.0",
 ]
 dynamic = [
     "version",
@@ -43,17 +44,19 @@ docs = [
     "sphinx-automodapi",
     "sphinx-rtd-theme",
     "stsci-rtd-theme",
+    "graphviz",
 ]
 test = [
-    "pytest>=7.0",
+    "pytest>=6.0",
+    "pytest-cov",
 ]
 
 [build-system]
 requires = [
-    "setuptools>=61.2",
-    "setuptools_scm[toml] >=6.2",
+    "setuptools>=30.3",
+    "setuptools_scm[toml]>=3.4",
     "wheel",
-    "numpy>=1.25,<2",
+    "oldest-supported-numpy; python_version>='3.7'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -84,4 +87,3 @@ all_files = "1"
 [tool.distutils.upload_docs]
 upload-dir = "docs/_build/html"
 show-response = 1
-

--- a/stsci/imagestats/__init__.py
+++ b/stsci/imagestats/__init__.py
@@ -157,21 +157,30 @@ class ImageStats:
             lower = self.min
 
         elif lower > self.max:
-            raise ValueError("Lower data cutoff is larger than maximum pixel value.\n"
-                             "Not enough data points to compute statistics.")
+            raise ValueError(
+                "Lower data cutoff is larger than maximum pixel value.\n"
+                "Not enough data points to compute statistics."
+            )
 
         elif upper is not None and lower > upper:
-            raise ValueError("Lower data cutoff must be smaller than upper cutoff limit.")
+            raise ValueError(
+                "Lower data cutoff must be smaller than upper cutoff limit."
+            )
 
         if upper is None:
             upper = self.max
 
         elif upper < self.min:
-            raise ValueError("Upper data cutoff is smaller than minimum pixel value.\n"
-                             "Not enough data points to compute statistics.")
+            raise ValueError(
+                "Upper data cutoff is smaller than minimum pixel value.\n"
+                "Not enough data points to compute statistics."
+            )
 
         elif lower > upper:
-            raise ValueError("Upper data cutoff cannot be smaller than the lower cutoff limit.")
+            raise ValueError(
+                "Upper data cutoff cannot be smaller than the lower cutoff "
+                "limit."
+            )
 
         self.lower = lower
         self.upper = upper
@@ -184,7 +193,7 @@ class ImageStats:
         self.deltaTime = self.stopTime - self.startTime
 
     def _error_no_valid_pixels(self, clipiter, minval, maxval, minclip, maxclip):
-        errormsg =  "\n##############################################\n"
+        errormsg = "\n##############################################\n"
         errormsg += "#                                            #\n"
         errormsg += "# ERROR:                                     #\n"
         errormsg += "#  Unable to compute image statistics.  No   #\n"
@@ -209,14 +218,18 @@ class ImageStats:
         _clipmax = self.upper
 
         # Compute the clipped mean iterating the user specified numer of iterations
-        for iter in range(self.nclip+1):
-
+        for iter in range(self.nclip + 1):
             try:
-                _npix,_mean,_stddev,_min,_max = computeMean(self.image,_clipmin,_clipmax)
-                #print("_npix,_mean,_stddev,_min,_max = ",_npix,_mean,_stddev,_min,_max)
+                _npix, _mean, _stddev, _min, _max = computeMean(
+                    self.image,
+                    _clipmin,
+                    _clipmax
+                )
             except:
-                raise SystemError("An error processing the array object information occured in \
-                                    the computeMean module of imagestats.")
+                raise SystemError(
+                    "An error processing the array object information occured "
+                    "in the computeMean module of imagestats."
+                )
 
             if _npix <= 0:
                 # Compute Global minimum and maximum
@@ -225,7 +238,9 @@ class ImageStats:
                     _clipmin, _clipmax
                 )
                 print(errormsg)
-                raise ValueError("Not enough data points to compute statistics.")
+                raise ValueError(
+                    "Not enough data points to compute statistics."
+                )
 
             if iter < self.nclip:
                 # Re-compute limits for iterations
@@ -243,7 +258,7 @@ class ImageStats:
             # clean-up intermediate product since it is no longer needed
             del _image
 
-        if ( (self.fields.find('mode') != -1) or (self.fields.find('midpt') != -1) ):
+        if ((self.fields.find('mode') != -1) or (self.fields.find('midpt') != -1)):
             # Populate the historgram
             _hwidth = self.binwidth * _stddev
             _drange = _max - _min
@@ -254,7 +269,7 @@ class ImageStats:
                 _dz = _drange
                 print("! WARNING: Clipped data falls within 1 histogram bin")
             else:
-                _nbins = int( (_max - _min) / _hwidth ) + 1
+                _nbins = int((_max - _min) / _hwidth) + 1
                 _dz = float(_max - _min) / float(_nbins - 1)
 
             _hist = histogram1d(self.image, _nbins, _dz, _min)
@@ -264,12 +279,12 @@ class ImageStats:
             if (self.fields.find('mode') != -1):
                 # Compute the mode, taking into account special cases
                 if _nbins == 1:
-                    _mode = _min + 0.5 *_hwidth
+                    _mode = _min + 0.5 * _hwidth
                 elif _nbins == 2:
                     if _bins[0] > _bins[1]:
-                        _mode = _min + 0.5 *_hwidth
+                        _mode = _min + 0.5 * _hwidth
                     elif _bins[0] < _bins[1]:
-                        _mode = _min + 1.5 *_hwidth
+                        _mode = _min + 1.5 * _hwidth
                     else:
                         _mode = _min + _hwidth
                 else:
@@ -286,7 +301,7 @@ class ImageStats:
                         if _denom == 0:
                             _mode = _min + (_peakindex + 0.5) * _hwidth
                         else:
-                            _mode = _peakindex + 1 + (0.5 * (int(_dh1) - int(_dh2))/_denom)
+                            _mode = _peakindex + 1 + (0.5 * (int(_dh1) - int(_dh2)) / _denom)
                             _mode = _min + ((_mode - 0.5) * _hwidth)
                 # Return the mode
                 self.mode = _mode
@@ -294,28 +309,28 @@ class ImageStats:
             if (self.fields.find('midpt') != -1):
                 # Compute a pseudo-Median Value using IRAF's algorithm
                 _binSum = np.cumsum(_bins).astype(np.float32)
-                _binSum = _binSum/_binSum[-1]
+                _binSum = _binSum / _binSum[-1]
                 _lo = np.where(_binSum >= 0.5)[0][0]
                 _hi = _lo + 1
 
                 _h1 = _min + _lo * _hwidth
                 if (_lo == 0):
-                    _hdiff = _binSum[_hi-1]
+                    _hdiff = _binSum[_hi - 1]
                 else:
-                    _hdiff = _binSum[_hi-1] - _binSum[_lo-1]
+                    _hdiff = _binSum[_hi - 1] - _binSum[_lo - 1]
 
                 if (_hdiff == 0):
                     _midpt = _h1
                 elif (_lo == 0):
                     _midpt = _h1 + 0.5 / _hdiff * _hwidth
                 else:
-                    _midpt = _h1 + (0.5 - _binSum[_lo-1])/_hdiff * _hwidth
+                    _midpt = _h1 + (0.5 - _binSum[_lo - 1]) / _hdiff * _hwidth
                 self.midpt = _midpt
 
             # These values will only be returned if the histogram is computed.
             self.hmin = _min + 0.5 * _hwidth
             self.hwidth = _hwidth
-            self.histogram  = _bins
+            self.histogram = _bins
 
         #Return values
         self.stddev = _stddev
@@ -332,19 +347,19 @@ class ImageStats:
         """ Print the requested statistics values for those fields specified on input. """
         print("--- Imagestats Results ---")
 
-        if (self.fields.find('npix') != -1 ):
-            print("Number of pixels  :  ",self.npix)
-        if (self.fields.find('min') != -1 ):
-            print("Minimum value     :  ",self.min)
-        if (self.fields.find('max') != -1 ):
-            print("Maximum value     :  ",self.max)
-        if (self.fields.find('stddev') != -1 ):
-            print("Standard Deviation:  ",self.stddev)
-        if (self.fields.find('mean') != -1 ):
-            print("Mean              :  ",self.mean)
-        if (self.fields.find('mode') != -1 ):
-            print("Mode              :  ",self.mode)
-        if (self.fields.find('median') != -1 ):
-            print("Median            :  ",self.median)
-        if (self.fields.find('midpt') != -1 ):
-            print("Midpt            :  ",self.midpt)
+        if (self.fields.find('npix') != -1):
+            print("Number of pixels  :  ", self.npix)
+        if (self.fields.find('min') != -1):
+            print("Minimum value     :  ", self.min)
+        if (self.fields.find('max') != -1):
+            print("Maximum value     :  ", self.max)
+        if (self.fields.find('stddev') != -1):
+            print("Standard Deviation:  ", self.stddev)
+        if (self.fields.find('mean') != -1):
+            print("Mean              :  ", self.mean)
+        if (self.fields.find('mode') != -1):
+            print("Mode              :  ", self.mode)
+        if (self.fields.find('median') != -1):
+            print("Median            :  ", self.median)
+        if (self.fields.find('midpt') != -1):
+            print("Midpt            :  ", self.midpt)

--- a/stsci/imagestats/histogram1d.py
+++ b/stsci/imagestats/histogram1d.py
@@ -54,18 +54,20 @@ class histogram1d:
 
     def _populateHistogram(self):
         """Call the C-code that actually populates the histogram"""
-        try :
+        try:
             buildHistogram.populate1DHist(self._data, self.histogram,
                 self.minValue, self.maxValue, self.binWidth)
         except:
             if ((self._data.max() - self._data.min()) < self.binWidth):
-                raise ValueError("In histogram1d class, the binWidth is "
-                                 "greater than the data range of the array "
-                                 "object.")
+                raise ValueError(
+                    "In histogram1d class, the binWidth is greater than the "
+                    "data range of the array object."
+                )
             else:
-                raise SystemError("An error processing the array object "
-                                  "information occured in the buildHistogram "
-                                  "module of histogram1d.")
+                raise SystemError(
+                    "An error processing the array object information occured "
+                    "in the buildHistogram module of histogram1d."
+                )
 
     def getCenters(self):
         """ Returns histogram's centers. """

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 envlist =
-    py{39,310,311,312,dev}-test
+    py{37,38,39,310,311,312}-test{,-devdeps}{,-cov}
+    codestyle
+    twine
+    bandit
+
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -9,8 +13,28 @@ requires =
 # Pass through the following environment variables which are needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI
 
+setenv =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
+deps =
+    pytest
+    xdist: pytest-xdist
+    cov: pytest-cov
+    numpy116: numpy==1.16.*
+    numpy120: numpy==1.20.*
+    numpy123: numpy==1.23.*
+
+commands_pre =
+    devdeps: pip install numpy>=0.0.dev0 --upgrade --pre
+    pip freeze
+
+commands =
+    pip freeze
+    !cov: pytest --pyargs stsci.imagestats {posargs}
+    cov: pytest --pyargs stsci.imagestats --cov stsci.imagestats --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
+
 # Run the tests in a temporary directory to make sure that we don't import
-# astropy from the source tree
+# stsci.imagestats from the source tree
 changedir = .tmp/{envname}
 
 # tox environments are constructed with so-called 'factors' (or terms)
@@ -23,18 +47,37 @@ changedir = .tmp/{envname}
 #
 description =
     run tests
+    devdeps: with the latest developer version of key dependencies
     cov: and test coverage
-
-deps =
-    numpy120: numpy==1.20.*
-    numpy122: numpy==1.22.*
-    numpy123: numpy==1.23.*
 
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed
 extras =
     test: test
 
+[testenv:codestyle]
+skip_install = true
+changedir = {toxinidir}/stsci
+description = check code style with flake8
+deps = flake8
+commands = flake8 imagestats --count
+
+[testenv:twine]
+skip_install = true
+changedir = {toxinidir}
+description = twine check dist tarball
+deps =
+    build
+    twine>=3.3
 commands =
     pip freeze
-    !cov: pytest --pyargs stsci.imagestats {posargs}
-    cov: pytest --pyargs stsci.imagestats --cov stsci.imagestats --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
+    python -m build --sdist .
+    twine check --strict dist/*
+
+[testenv:bandit]
+skip_install = true
+changedir = {toxinidir}
+description = Security audit with bandit
+deps = bandit
+commands =
+    pip freeze
+    bandit imagestats -r -x stsci/imagestats/tests


### PR DESCRIPTION
Closes #29 
Closes #28

- lowered various version requirements
- expanded test matrix to include Python 3.7-3.12
- test against numpy 1.16 and 2.0(dev)
- fix pep8 errors
- added test coverage
