### PR TITLE
reformat `tox.ini` and ensure `-devdeps` test builds with >= Numpy 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        # Make sure that packaging will work
-        - name: pep517 build
-          linux: twine
-
         - name: Security audit
           linux: bandit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,3 @@ jobs:
           posargs: -v
           coverage: codecov
 
-        - name: Python 3.12 with dev version of dependencies
-          linux: py312-test-devdeps
-          posargs: -v

--- a/.github/workflows/devdeps.yml
+++ b/.github/workflows/devdeps.yml
@@ -1,0 +1,51 @@
+name: test with development versions
+
+on:
+  push:
+    branches:
+      - main
+      - '*x'
+    tags:
+      - '*'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+  schedule:
+    # Weekly Monday 9AM build
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    if: (github.repository == 'spacetelescope/stsci.imagestats' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: py39-devdeps
+        - linux: py39-devdeps
+        - macos: py39-devdeps
+        - macos: py39-devdeps
+        - linux: py310-devdeps
+        - linux: py310-devdeps
+        - macos: py310-devdeps
+        - macos: py310-devdeps
+        - linux: py311-devdeps
+        - linux: py311-devdeps
+        - macos: py311-devdeps
+        - macos: py311-devdeps
+        - linux: py3-devdeps
+          pytest-results-summary: true
+        - linux: py3-devdeps
+          pytest-results-summary: true
+        - macos: py3-devdeps
+          pytest-results-summary: true
+        - macos: py3-devdeps
+          pytest-results-summary: true

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands_pre =
     pip freeze
 commands =
     pytest --pyargs stsci.imagestats \
-    cov: --cov stsci/imagestats --cov-config pyproject.toml --cov-report xml:coverage.xml \
+    cov: --cov stsci/imagestats --cov-report term-missing \
     {posargs}
 
 [tool.build-sphinx]

--- a/tox.ini
+++ b/tox.ini
@@ -1,55 +1,45 @@
 [tox]
 envlist =
     py{37,38,39,310,311,312}-test{,-devdeps,-numpy116,-numpy120,-numpy123}{,-cov}
-    codestyle
-    twine
-    bandit
-
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 
 [testenv]
-# Pass through the following environment variables which are needed for the CI
-passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI
-
-setenv =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-
-deps =
-    cov: pytest-cov
-
-    numpy116: numpy==1.16.*
-    numpy120: numpy==1.20.*
-    numpy123: numpy==1.23.*
-
-    devdeps: numpy>=0.0.dev0
-
-commands =
-    pip freeze
-    !cov: pytest --pyargs stsci.imagestats {posargs}
-    cov: pytest --pyargs stsci.imagestats --cov stsci.imagestats --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
-
-# Run the tests in a temporary directory to make sure that we don't import
-# stsci.imagestats from the source tree
-changedir = .tmp/{envname}
-
-# tox environments are constructed with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
 description =
     run tests
     devdeps: with the latest developer version of key dependencies
     cov: and test coverage
-
+# Pass through the following environment variables which are needed for the CI
+passenv = 
+    HOME
+    WINDIR
+    LC_ALL
+    LC_CTYPE
+    CC
+    CI
+    IS_CRON
+    ARCH_ON_CI
+setenv =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+# Run the tests in a temporary directory to make sure that we don't import
+# stsci.imagestats from the source tree
+changedir = .tmp/{envname}
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed
 extras =
     test
+deps =
+    cov: pytest-cov
+    numpy116: numpy==1.16.*
+    numpy120: numpy==1.20.*
+    numpy123: numpy==1.23.*
+    devdeps: numpy>=0.0.dev0
+commands_pre =
+    pip freeze
+commands =
+    pytest --pyargs stsci.imagestats \
+    --cov stsci/imagestats --cov-config pyproject.toml --cov-report xml:coverage.xml \
+    {posargs}
 
 [tool.build-sphinx]
 source-dir = "docs"

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
-envlist =
+env_list =
     py{37,38,39,310,311,312}-test{,-devdeps,-numpy116,-numpy120,-numpy123}{,-cov}
-requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
 
 [testenv]
 description =
@@ -11,7 +8,7 @@ description =
     devdeps: with the latest developer version of key dependencies
     cov: and test coverage
 # Pass through the following environment variables which are needed for the CI
-passenv = 
+pass_env = 
     HOME
     WINDIR
     LC_ALL
@@ -20,11 +17,11 @@ passenv =
     CI
     IS_CRON
     ARCH_ON_CI
-setenv =
+set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 # Run the tests in a temporary directory to make sure that we don't import
 # stsci.imagestats from the source tree
-changedir = .tmp/{envname}
+changedir = .tmp/{env_name}
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed
 extras =
     test
@@ -52,26 +49,14 @@ show-response = 1
 
 [testenv:codestyle]
 skip_install = true
-changedir = {toxinidir}/stsci
+changedir = {tox_root}/stsci
 description = check code style with flake8
 deps = flake8
 commands = flake8 imagestats --count
 
-[testenv:twine]
-skip_install = true
-changedir = {toxinidir}
-description = twine check dist tarball
-deps =
-    build
-    twine>=3.3
-commands =
-    pip freeze
-    python -m build --sdist .
-    twine check --strict dist/*
-
 [testenv:bandit]
 skip_install = true
-changedir = {toxinidir}
+changedir = {tox_root}
 description = Security audit with bandit
 deps = bandit
 commands =
@@ -84,10 +69,3 @@ extras = docs
 commands =
     sphinx-build docs/ docs/_build
 
-[testenv:build-dist]
-description = build wheel and sdist
-skip_install = true
-deps =
-    build
-commands =
-    python -m build .

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     numpy116: numpy==1.16.*
     numpy120: numpy==1.20.*
     numpy123: numpy==1.23.*
-    devdeps: numpy>=0.0.dev0
+    devdeps: numpy>=2.0.dev0
 commands_pre =
     pip freeze
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands_pre =
     pip freeze
 commands =
     pytest --pyargs stsci.imagestats \
-    --cov stsci/imagestats --cov-config pyproject.toml --cov-report xml:coverage.xml \
+    cov: --cov stsci/imagestats --cov-config pyproject.toml --cov-report xml:coverage.xml \
     {posargs}
 
 [tool.build-sphinx]


### PR DESCRIPTION
attempts to fix issue in #50 where `-devdeps` fails due to incongruous Numpy versions between build and test
https://github.com/spacetelescope/stsci.imagestats/actions/runs/6919409096/job/18822748363?pr=50