### PR TITLE
Improve handling of FLT accurary errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,14 @@
 Release Notes
 =============
 
-.. 1.8.1 (unreleased)
+.. 1.8.2 (unreleased)
    ==================
+
+1.8.1 (22-March-2024)
+=====================
+
+- Bug Fix: Improve handling of floating point accuracy issues that can lead to
+  memory violation on some systems. [#58]
 
 1.8.0 (07-December-2023)
 ========================


### PR DESCRIPTION
This PR fixes a random memory violation reported on some Linux systems that result from `idx` variable in the `populate1DHist_` function going past allocated memory for the histogram.

All of the hard debugging work was done by @jhunkeler who also helped testing proposed fix.