### PR TITLE
re-enable macOS ARM64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
         # MacOS wheels
         - cp3*-macosx_x86_64
         # Until we have arm64 runners, we can't automatically test arm64 wheels
-        # Disabling this due to permission errors
-        # - cp3*-macosx_arm64
+        - cp3*-macosx_arm64
         # Windows wheels
         - cp3*-win32
         - cp3*-win_amd64


### PR DESCRIPTION
OpenAstronomy actions are fixed and the build is green 🎊 