### PR TITLE
Prepare for release 1.8.4 (was 1.9.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@
 Release Notes
 =============
 
-1.9.0 (03-November-2025)
+1.8.4 (03-November-2025)
 ========================
 
 - Added support for Python 3.13 and 3.14. Package maintenance.


### PR DESCRIPTION
Update changelog for next release. It is a maintenance release.