### PR TITLE
[SCSB-274] localize build workflow for trusted publishers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3"
+          pip-install: build
       - if: ${{ runner.os == 'Linux' }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
@@ -37,7 +38,6 @@ jobs:
         with:
           package-dir: ./
           output-dir: dist/
-      - run: pip install build
       - run: python -m build --sdist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,44 +10,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     strategy:
       matrix:
-        target:
-          # Linux wheels
-          - cp39-manylinux_x86_64
-          # MacOS wheels
-          - cp39-macosx_x86_64
-          - cp39-macosx_arm64
-          # Windows wheels
-          - cp39-win32
-          - cp39-win_amd64
-    runs-on: ${{ contains(matrix.target, 'macos') && 'macos-latest' || contains(matrix.target, 'win') && 'windows-latest' || 'ubuntu-latest' }}
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
+          fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3"
       - if: ${{ runner.os == 'Linux' }}
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         with:
           package-dir: ./
           output-dir: dist/
-        env:
-          CIBW_BUILD: ${{ matrix.target }}
-          CIBW_ARCHS: ${{ runner.os == 'macOS' && 'arm64 x86_64' || 'auto' }}
       - run: pip install build
       - run: python -m build --sdist
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist-${{ matrix.target }}
+          name: dist-${{ runner.os }}-${{ runner.arch }}
           path: ./dist/
   publish:
     if: (github.event_name == 'release') && (github.event.action == 'released')
@@ -56,19 +50,22 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-    # Requires environment protection rules in GitHub Settings:
+    # To add required reviewers before deployment,
+    # edit the protection rules in GitHub Settings:
     # Settings > Environments > pypi > Add required reviewers
     environment:
       name: pypi
       url: https://pypi.org/p/stsci.imagestats
     steps:
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: dist*
           path: dist/
           merge-multiple: true
-      - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      - uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "dist/*"
       # To upload to PyPI without a token, add this workflow file as a Trusted Publisher in the project settings on the PyPI website
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,44 +1,74 @@
 name: build
 
 on:
+  pull_request:
   release:
     types: [released]
-  pull_request:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c  # v2.4.0
-    with:
-      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-      save_artifacts: true
-      targets: |
-        # Linux wheels
-        - cp39-manylinux_x86_64
-        # MacOS wheels
-        - cp39-macosx_x86_64
-        - cp39-macosx_arm64
-        # Windows wheels
-        - cp39-win32
-        - cp39-win_amd64
-      sdist: true
-      test_command: python -c "from stsci.imagestats import buildHistogram, computeMean"
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
-  test_wheel:
-    needs: build
+    strategy:
+      matrix:
+        target:
+          # Linux wheels
+          - cp39-manylinux_x86_64
+          # MacOS wheels
+          - cp39-macosx_x86_64
+          - cp39-macosx_arm64
+          # Windows wheels
+          - cp39-win32
+          - cp39-win_amd64
+    runs-on: ${{ contains(matrix.target, 'macos') && 'macos-latest' || contains(matrix.target, 'win') && 'windows-latest' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3"
+      - if: ${{ runner.os == 'Linux' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        with:
+          package-dir: ./
+          output-dir: dist/
+        env:
+          CIBW_BUILD: ${{ matrix.target }}
+          CIBW_ARCHS: ${{ runner.os == 'macOS' && 'arm64 x86_64' || 'auto' }}
+      - run: pip install build
+      - run: python -m build --sdist
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: dist-${{ matrix.target }}
+          path: ./dist/
+  publish:
+    if: (github.event_name == 'release') && (github.event.action == 'released')
+    needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    # Requires environment protection rules in GitHub Settings:
+    # Settings > Environments > pypi > Add required reviewers
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stsci.imagestats
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          pattern: dist-*
-          path: dist
+          pattern: dist*
+          path: dist/
           merge-multiple: true
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - run: "pip install abi3audit"
-      - run: "abi3audit --strict --report dist/*.whl"
-        shell: sh
+      - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: "dist/*"
+      # To upload to PyPI without a token, add this workflow file as a Trusted Publisher in the project settings on the PyPI website
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 test-requires = ["abi3audit"]
-test-command = "python -c 'from stsci.imagestats import buildHistogram, computeMean' && abi3audit --strict --report dist/*.whl"
+test-command = 'python -c "from stsci.imagestats import buildHistogram, computeMean" && abi3audit --strict --report dist/*.whl'
 
 [tool.setuptools]
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp39-*"  # build for CPython 3.9 Stable API
-skip = ["cp3*t-*"]  # explicitly skip free-threaded builds
+build = [
+    "cp39-*",  # build for CPython 3.9 Stable API
+    "cp3*t-*",  # build for free-threaded Python
+]
 test-command = "python -c 'from stsci.imagestats import buildHistogram, computeMean'"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.cibuildwheel]
+test-requires = ["abi3audit"]
+test-command = "python -c 'from stsci.imagestats import buildHistogram, computeMean' && abi3audit --strict --report dist/*.whl"
+
 [tool.setuptools]
 zip-safe = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,9 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-test-requires = ["abi3audit"]
-test-command = 'python -c "from stsci.imagestats import buildHistogram, computeMean" && abi3audit --strict --report dist/*.whl'
+build = "cp39-*"  # build for CPython 3.9 Stable API
+skip = ["cp3*t-*"]  # explicitly skip free-threaded builds
+test-command = "python -c 'from stsci.imagestats import buildHistogram, computeMean'"
 
 [tool.setuptools]
 zip-safe = false

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,13 @@ import sysconfig
 import numpy
 from setuptools import Extension, find_namespace_packages, setup
 
+FREE_THREADED_PYTHON = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+
 # Setup C module include directories
 include_dirs = [numpy.get_include()]
-define_macros = [("Py_LIMITED_API", "0x03090000")]
+define_macros = []
+if not FREE_THREADED_PYTHON:
+    define_macros.append(("Py_LIMITED_API", "0x03090000"))  # PY_VERSION_HEX for 3.9
 
 # Handle MSVC `wcsset` redefinition
 if sys.platform == "win32":
@@ -20,6 +24,10 @@ if cflags:
     extra_compile_args += ["-DNDEBUG", "-O2"]
 else:
     extra_compile_args = None
+
+SETUPTOOLS_OPTIONS = {}
+if not FREE_THREADED_PYTHON:
+    SETUPTOOLS_OPTIONS["bdist_wheel"] = {"py_limited_api": "cp39"}
 
 setup(
     packages=find_namespace_packages(where=".", include=["stsci", "stsci.imagestats"]),
@@ -43,5 +51,5 @@ setup(
             py_limited_api=True,
         ),
     ],
-    options={'bdist_wheel': {'py_limited_api': 'cp39'}},
+    options=SETUPTOOLS_OPTIONS,
 )


### PR DESCRIPTION
borrowing some changes from #93 

also moves the cibuildwheel config to `pyproject.toml`, and enables building free-threaded wheels for each new Python version